### PR TITLE
comment out deploy job in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,42 +189,42 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-  deploy:
-    name: 🚀 Deploy
-    runs-on: ubuntu-24.04
-    # needs: [lint, typecheck, vitest, playwright, container]
-    needs: [lint, typecheck, vitest, container]
-    # only deploy on pushes
-    if: ${{ github.event_name == 'push' }}
-    steps:
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: '50'
+  # deploy:
+  #   name: 🚀 Deploy
+  #   runs-on: ubuntu-24.04
+  #   # needs: [lint, typecheck, vitest, playwright, container]
+  #   needs: [lint, typecheck, vitest, container]
+  #   # only deploy on pushes
+  #   if: ${{ github.event_name == 'push' }}
+  #   steps:
+  #     - name: ⬇️ Checkout repo
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: '50'
 
-      - name: 👀 Read app name
-        uses: SebRollen/toml-action@v1.2.0
-        id: app_name
-        with:
-          file: 'fly.toml'
-          field: 'app'
+  #     - name: 👀 Read app name
+  #       uses: SebRollen/toml-action@v1.2.0
+  #       id: app_name
+  #       with:
+  #         file: 'fly.toml'
+  #         field: 'app'
 
-      - name: 🎈 Setup Fly
-        uses: superfly/flyctl-actions/setup-flyctl@1.5
+  #     - name: 🎈 Setup Fly
+  #       uses: superfly/flyctl-actions/setup-flyctl@1.5
 
-      - name: 🚀 Deploy Staging
-        if: ${{ github.ref == 'refs/heads/dev' }}
-        run: |
-          flyctl deploy \
-            --image "registry.fly.io/${{ steps.app_name.outputs.value }}-staging:${{ github.sha }}" \
-            --app ${{ steps.app_name.outputs.value }}-staging
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  #     - name: 🚀 Deploy Staging
+  #       if: ${{ github.ref == 'refs/heads/dev' }}
+  #       run: |
+  #         flyctl deploy \
+  #           --image "registry.fly.io/${{ steps.app_name.outputs.value }}-staging:${{ github.sha }}" \
+  #           --app ${{ steps.app_name.outputs.value }}-staging
+  #       env:
+  #         FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: 🚀 Deploy Production
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          flyctl deploy \
-            --image "registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.sha }}"
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  #     - name: 🚀 Deploy Production
+  #       if: ${{ github.ref == 'refs/heads/main' }}
+  #       run: |
+  #         flyctl deploy \
+  #           --image "registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.sha }}"
+  #       env:
+  #         FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
This pull request comments out the entire deploy job in the GitHub Actions workflow file `.github/workflows/deploy.yml`. As a result, automated deployments to both staging and production environments will be disabled until the job is re-enabled.

Workflow changes:

* Commented out the `deploy` job, which includes all steps for deploying to both staging and production using Fly.io. This prevents automatic deployments on pushes to the `dev` and `main` branches.<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
