### PR TITLE
Profile settings

### DIFF
--- a/app/components/ui/alert.tsx
+++ b/app/components/ui/alert.tsx
@@ -1,0 +1,58 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+import { cn } from '#app/utils/misc.tsx'
+
+const alertVariants = cva(
+	'[&>svg]:text-foreground relative w-full rounded-lg border p-4 [&>svg]:absolute [&>svg]:top-4 [&>svg]:left-4 [&>svg+div]:translate-y-[-3px] [&>svg~*]:pl-7',
+	{
+		variants: {
+			variant: {
+				default: 'bg-background text-foreground',
+				destructive:
+					'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+		},
+	},
+)
+
+const Alert = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+	<div
+		ref={ref}
+		role="alert"
+		className={cn(alertVariants({ variant }), className)}
+		{...props}
+	/>
+))
+Alert.displayName = 'Alert'
+
+const AlertTitle = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+	<h5
+		ref={ref}
+		className={cn('mb-1 leading-none font-medium tracking-tight', className)}
+		{...props}
+	/>
+))
+AlertTitle.displayName = 'AlertTitle'
+
+const AlertDescription = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		className={cn('text-sm [&_p]:leading-relaxed', className)}
+		{...props}
+	/>
+))
+AlertDescription.displayName = 'AlertDescription'
+
+export { Alert, AlertTitle, AlertDescription }

--- a/app/components/ui/breadcrumb.tsx
+++ b/app/components/ui/breadcrumb.tsx
@@ -1,0 +1,114 @@
+import { Slot } from '@radix-ui/react-slot'
+import * as React from 'react'
+import { cn } from '#app/utils/misc.tsx'
+import { Icon } from './icon'
+
+const Breadcrumb = React.forwardRef<
+	HTMLElement,
+	React.ComponentPropsWithoutRef<'nav'> & {
+		separator?: React.ReactNode
+	}
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />)
+Breadcrumb.displayName = 'Breadcrumb'
+
+const BreadcrumbList = React.forwardRef<
+	HTMLOListElement,
+	React.ComponentPropsWithoutRef<'ol'>
+>(({ className, ...props }, ref) => (
+	<ol
+		ref={ref}
+		className={cn(
+			'text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5',
+			className,
+		)}
+		{...props}
+	/>
+))
+BreadcrumbList.displayName = 'BreadcrumbList'
+
+const BreadcrumbItem = React.forwardRef<
+	HTMLLIElement,
+	React.ComponentPropsWithoutRef<'li'>
+>(({ className, ...props }, ref) => (
+	<li
+		ref={ref}
+		className={cn('inline-flex items-center gap-1.5', className)}
+		{...props}
+	/>
+))
+BreadcrumbItem.displayName = 'BreadcrumbItem'
+
+const BreadcrumbLink = React.forwardRef<
+	HTMLAnchorElement,
+	React.ComponentPropsWithoutRef<'a'> & {
+		asChild?: boolean
+	}
+>(({ asChild, className, ...props }, ref) => {
+	const Comp = asChild ? Slot : 'a'
+
+	return (
+		<Comp
+			ref={ref}
+			className={cn('hover:text-foreground transition-colors', className)}
+			{...props}
+		/>
+	)
+})
+BreadcrumbLink.displayName = 'BreadcrumbLink'
+
+const BreadcrumbPage = React.forwardRef<
+	HTMLSpanElement,
+	React.ComponentPropsWithoutRef<'span'>
+>(({ className, ...props }, ref) => (
+	<span
+		ref={ref}
+		role="link"
+		aria-disabled="true"
+		aria-current="page"
+		className={cn('text-foreground font-normal', className)}
+		{...props}
+	/>
+))
+BreadcrumbPage.displayName = 'BreadcrumbPage'
+
+const BreadcrumbSeparator = ({
+	children,
+	className,
+	...props
+}: React.ComponentProps<'li'>) => (
+	<li
+		role="presentation"
+		aria-hidden="true"
+		className={cn('[&>svg]:h-3.5 [&>svg]:w-3.5', className)}
+		{...props}
+	>
+		{children ?? <Icon name="chevron-right" />}
+	</li>
+)
+BreadcrumbSeparator.displayName = 'BreadcrumbSeparator'
+
+const BreadcrumbEllipsis = ({
+	className,
+	...props
+}: React.ComponentProps<'span'>) => (
+	<span
+		role="presentation"
+		aria-hidden="true"
+		className={cn('flex h-9 w-9 items-center justify-center', className)}
+		{...props}
+	>
+		<Icon name="ellipsis" className="h-4 w-4" />
+		<span className="sr-only">More</span>
+	</span>
+)
+BreadcrumbEllipsis.displayName = 'BreadcrumbElipssis'
+
+export {
+	Breadcrumb,
+	BreadcrumbList,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+	BreadcrumbEllipsis,
+}

--- a/app/components/user-dropdown.tsx
+++ b/app/components/user-dropdown.tsx
@@ -48,13 +48,6 @@ export function UserDropdown() {
 							</Icon>
 						</Link>
 					</DropdownMenuItem>
-					<DropdownMenuItem asChild>
-						<Link prefetch="intent" to={`/users/${user.username}/notes`}>
-							<Icon className="text-body-md" name="pencil-2">
-								Notes
-							</Icon>
-						</Link>
-					</DropdownMenuItem>
 					<Form action="/logout" method="POST" ref={formRef}>
 						<DropdownMenuItem asChild>
 							<button type="submit" className="w-full">

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -241,15 +241,25 @@ function App() {
 						{user ? (
 							<UserDropdown />
 						) : (
-							<Button variant="ghost" size="sm">
-								Sign In
+							<Button asChild variant="ghost" size="sm">
+								<Link to="/login" prefetch="intent">
+									Sign In
+								</Link>
 							</Button>
 						)}
-						<Button size="sm" asChild>
-							<Link to="/vendors/onboarding/hint" prefetch="intent">
-								Join as Vendor
-							</Link>
-						</Button>
+						{user?.vendor?.id ? (
+							<Button size="sm" asChild>
+								<Link to={`/vendors/${user.vendor.slug}`} prefetch="intent">
+									Vendor Profile
+								</Link>
+							</Button>
+						) : (
+							<Button size="sm" asChild>
+								<Link to="/vendors/onboarding/hint" prefetch="intent">
+									Join as Vendor
+								</Link>
+							</Button>
+						)}
 					</div>
 				</div>
 			</header>

--- a/app/routes/_auth+/forgot-password.tsx
+++ b/app/routes/_auth+/forgot-password.tsx
@@ -114,7 +114,7 @@ function ForgotPasswordEmail({
 }
 
 export const meta: Route.MetaFunction = () => {
-	return [{ title: 'Password Recovery for Epic Notes' }]
+	return [{ title: 'Password Recovery for ShuvoDin' }]
 }
 
 export default function ForgotPasswordRoute() {

--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -299,7 +299,7 @@ function PasskeyLogin({
 }
 
 export const meta: Route.MetaFunction = () => {
-	return [{ title: 'Login to Epic Notes' }]
+	return [{ title: 'Login to ShuvoDin' }]
 }
 
 export function ErrorBoundary() {

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -128,7 +128,7 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export const meta: Route.MetaFunction = () => {
-	return [{ title: 'Setup Epic Notes Account' }]
+	return [{ title: 'Setup ShuvoDin Account' }]
 }
 
 export default function OnboardingRoute({

--- a/app/routes/_auth+/onboarding_.$provider.tsx
+++ b/app/routes/_auth+/onboarding_.$provider.tsx
@@ -160,7 +160,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 }
 
 export const meta: Route.MetaFunction = () => {
-	return [{ title: 'Setup Epic Notes Account' }]
+	return [{ title: 'Setup ShuvoDin Account' }]
 }
 
 export default function OnboardingProviderRoute({

--- a/app/routes/_auth+/reset-password.tsx
+++ b/app/routes/_auth+/reset-password.tsx
@@ -76,7 +76,7 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export const meta: Route.MetaFunction = () => {
-	return [{ title: 'Reset Password | Epic Notes' }]
+	return [{ title: 'Reset Password | ShuvoDin' }]
 }
 
 export default function ResetPasswordPage({

--- a/app/routes/_auth+/signup.tsx
+++ b/app/routes/_auth+/signup.tsx
@@ -72,7 +72,7 @@ export async function action({ request }: Route.ActionArgs) {
 
 	const response = await sendEmail({
 		to: email,
-		subject: `Welcome to Epic Notes!`,
+		subject: `Welcome to ShuvoDin!`,
 		react: <SignupEmail onboardingUrl={verifyUrl.toString()} otp={otp} />,
 	})
 
@@ -101,7 +101,7 @@ export function SignupEmail({
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>Welcome to Epic Notes!</E.Text>
+					<E.Text>Welcome to ShuvoDin!</E.Text>
 				</h1>
 				<p>
 					<E.Text>
@@ -118,7 +118,7 @@ export function SignupEmail({
 }
 
 export const meta: Route.MetaFunction = () => {
-	return [{ title: 'Sign Up | Epic Notes' }]
+	return [{ title: 'Sign Up | ShuvoDin' }]
 }
 
 export default function SignupRoute({ actionData }: Route.ComponentProps) {

--- a/app/routes/profiles+/$username.tsx
+++ b/app/routes/profiles+/$username.tsx
@@ -36,7 +36,7 @@ function getStatusColor(status: string) {
 
 export const meta = ({ data }: Route.MetaArgs) => {
 	return [
-		{ title: `${data?.user.username} / ShuvoDin` },
+		{ title: `${data?.user.name ?? data?.user.username} / ShuvoDin` },
 		{
 			name: 'description',
 			content: `ShuvoDin ${data?.user.name || data?.user.username} Profile!`,

--- a/app/routes/profiles+/$username.tsx
+++ b/app/routes/profiles+/$username.tsx
@@ -425,7 +425,7 @@ export default function VendorRoute({
 
 						<div className="flex gap-3">
 							<Button asChild variant="outline" size="sm">
-								<Link to="/settings/profile">
+								<Link to="/settings/account">
 									<Icon name="settings" className="mr-2 h-4 w-4" />
 									Settings
 								</Link>

--- a/app/routes/profiles+/$username_+/notes.$noteId.tsx
+++ b/app/routes/profiles+/$username_+/notes.$noteId.tsx
@@ -218,7 +218,7 @@ export const meta: Route.MetaFunction = ({ data, params, matches }) => {
 			? data?.note.description?.slice(0, 97) + '...'
 			: 'No content'
 	return [
-		{ title: `${noteTitle} | ${displayName}'s Notes | Epic Notes` },
+		{ title: `${noteTitle} | ${displayName}'s Notes | ShuvoDin` },
 		{
 			name: 'description',
 			content: noteContentsSummary,

--- a/app/routes/profiles+/$username_+/notes.index.tsx
+++ b/app/routes/profiles+/$username_+/notes.index.tsx
@@ -18,10 +18,10 @@ export const meta: Route.MetaFunction = ({ params, matches }) => {
 	// const noteCount = notesMatch?.data?.owner.notes.length ?? 0
 	// const notesText = noteCount === 1 ? 'note' : 'notes'
 	return [
-		{ title: `${displayName}'s Notes | Epic Notes` },
+		{ title: `${displayName}'s Notes | ShuvoDin` },
 		{
 			name: 'description',
-			content: `Checkout ${displayName}'s  on Epic Notes`,
+			content: `Checkout ${displayName}'s  on ShuvoDin`,
 		},
 	]
 }

--- a/app/routes/settings+/_layout.tsx
+++ b/app/routes/settings+/_layout.tsx
@@ -14,7 +14,7 @@ import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { cn } from '#app/utils/misc.tsx'
 import { type Route } from './+types/_layout'
-import { type IconName } from '@/icon-name'
+import { type IconName } from '#app/components/ui/icon.tsx'
 
 const navigationItems = [
 	{

--- a/app/routes/settings+/_layout.tsx
+++ b/app/routes/settings+/_layout.tsx
@@ -9,12 +9,11 @@ import {
 	BreadcrumbSeparator,
 } from '#app/components/ui/breadcrumb.tsx'
 import { Button } from '#app/components/ui/button.tsx'
-import { Icon } from '#app/components/ui/icon.tsx'
+import { type IconName, Icon } from '#app/components/ui/icon.tsx'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { cn } from '#app/utils/misc.tsx'
 import { type Route } from './+types/_layout'
-import { type IconName } from '#app/components/ui/icon.tsx'
 
 const navigationItems = [
 	{

--- a/app/routes/settings+/_layout.tsx
+++ b/app/routes/settings+/_layout.tsx
@@ -43,7 +43,7 @@ const navigationItems = [
 				title: 'Two-Factor Authentication',
 				href: '/settings/security/2FA',
 				type: 'default',
-				icon: 'lock',
+				icon: 'monitor-smartphone',
 				description: 'Secure your account with 2FA',
 			},
 			{
@@ -57,7 +57,7 @@ const navigationItems = [
 				title: 'Manage Passkeys',
 				href: '/settings/security/passkeys',
 				type: 'default',
-				icon: 'key',
+				icon: 'lock',
 				description: 'Biometric and security keys',
 			},
 		],

--- a/app/routes/settings+/_layout.tsx
+++ b/app/routes/settings+/_layout.tsx
@@ -1,0 +1,244 @@
+import { invariantResponse } from '@epic-web/invariant'
+import { Link, Outlet, useLocation } from 'react-router'
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+} from '#app/components/ui/breadcrumb.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import { Icon } from '#app/components/ui/icon.tsx'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { type Route } from './+types/_layout'
+import { type IconName } from '@/icon-name'
+import { cn } from '#app/utils/misc.tsx'
+
+const navigationItems = [
+	{
+		title: 'Account',
+		items: [
+			{
+				title: 'Profile Information',
+				href: '/settings/account',
+				type: 'default',
+				icon: 'user',
+				description: 'Update your personal details',
+			},
+		],
+	},
+	{
+		title: 'Security',
+		items: [
+			{
+				title: 'Change Email',
+				href: '/settings/security/change-email',
+				type: 'default',
+				icon: 'shield',
+				description: 'Update your email address',
+			},
+			{
+				title: 'Two-Factor Authentication',
+				href: '/settings/security/2FA',
+				type: 'default',
+				icon: 'lock',
+				description: 'Secure your account with 2FA',
+			},
+			{
+				title: 'Change Password',
+				href: '/settings/security/password',
+				type: 'default',
+				icon: 'key',
+				description: 'Update your password',
+			},
+			{
+				title: 'Manage Passkeys',
+				href: '/settings/security/passkeys',
+				type: 'default',
+				icon: 'key',
+				description: 'Biometric and security keys',
+			},
+		],
+	},
+	{
+		title: 'Privacy & Data',
+		items: [
+			{
+				title: 'Download Your Data',
+				href: '/settings/privacy/download',
+				type: 'default',
+				icon: 'download',
+				description: 'Export your account data',
+			},
+		],
+	},
+	{
+		title: 'Sessions',
+		items: [
+			{
+				title: 'Active Sessions',
+				href: '/settings/sessions',
+				type: 'default',
+				icon: 'monitor',
+				description: 'Manage your login sessions',
+			},
+		],
+	},
+	{
+		title: 'Danger Zone',
+		items: [
+			{
+				title: 'Delete Account',
+				href: '/settings/security/delete-account',
+				type: 'destructive',
+				icon: 'trash-2',
+				description: 'Permanently delete your account',
+			},
+		],
+	},
+]
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const userId = await requireUserId(request)
+	const user = await prisma.user.findUnique({
+		where: { id: userId },
+		select: { username: true },
+	})
+	invariantResponse(user, 'User not found', { status: 404 })
+	return {}
+}
+
+function SettingsNavigation() {
+	const { pathname } = useLocation()
+
+	return (
+		<nav className="space-y-6">
+			{navigationItems.map((section) => (
+				<div key={section.title}>
+					<h3 className="text-muted-foreground mb-2 px-2 text-sm font-semibold">
+						{section.title}
+					</h3>
+					<div className="space-y-1">
+						{section.items.map((item) => {
+							const isActive = pathname.includes(item.href)
+
+							return (
+								<Link
+									key={item.href}
+									to={item.href}
+									className={cn(
+										'hover:bg-accent hover:text-accent-foreground flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
+										{ 'bg-accent text-accent-foreground': isActive },
+										{
+											'text-destructive hover:text-destructive':
+												item.type === 'destructive',
+										},
+									)}
+								>
+									<Icon name={item.icon as IconName} />
+									<div className="flex-1">
+										<div className="font-medium">{item.title}</div>
+										<div className="text-muted-foreground text-xs">
+											{item.description}
+										</div>
+									</div>
+								</Link>
+							)
+						})}
+					</div>
+				</div>
+			))}
+		</nav>
+	)
+}
+
+function SettingsBreadcrumb() {
+	const { pathname } = useLocation()
+	const segments = pathname.split('/').filter(Boolean)
+
+	const getBreadcrumbTitle = (segment: string, index: number) => {
+		const path = '/' + segments.slice(0, index + 1).join('/')
+		const item = navigationItems
+			.flatMap((section) => section.items)
+			.find((item) => item.href === path)
+
+		if (item) return item.title
+
+		// Fallback formatting
+		return segment
+			.split('-')
+			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+			.join(' ')
+	}
+
+	return (
+		<Breadcrumb>
+			<BreadcrumbList>
+				<BreadcrumbItem>
+					<BreadcrumbLink href="/settings">Settings</BreadcrumbLink>
+				</BreadcrumbItem>
+				{segments.slice(1).map((segment, index) => (
+					<div key={segment} className="flex items-center gap-1.5 sm:gap-2.5">
+						<BreadcrumbSeparator />
+						<BreadcrumbItem>
+							{index === segments.length - 2 ? (
+								<BreadcrumbPage>
+									{getBreadcrumbTitle(segment, index + 1)}
+								</BreadcrumbPage>
+							) : (
+								<BreadcrumbLink
+									href={`/${segments.slice(0, index + 2).join('/')}`}
+								>
+									{getBreadcrumbTitle(segment, index + 1)}
+								</BreadcrumbLink>
+							)}
+						</BreadcrumbItem>
+					</div>
+				))}
+			</BreadcrumbList>
+		</Breadcrumb>
+	)
+}
+
+export default function SettingsLayout() {
+	return (
+		<div className="min-h-screen">
+			<div className="container mx-auto px-4 py-8">
+				<div className="mb-6 flex items-center justify-between">
+					<div>
+						<h1 className="text-3xl font-bold">Settings</h1>
+						<p className="text-muted-foreground">
+							Manage your account settings and preferences
+						</p>
+					</div>
+					<div className="flex items-center gap-2">
+						<Button variant="outline" size="sm" asChild>
+							<Link
+								reloadDocument
+								download="my-shuvodin-data.json"
+								to="/resources/download-user-data"
+							>
+								<Icon name="download" className="mr-2 h-4 w-4" />
+								Download Data
+							</Link>
+						</Button>
+					</div>
+				</div>
+
+				<SettingsBreadcrumb />
+
+				<div className="mt-10 grid grid-cols-1 gap-10 sm:gap-20 lg:grid-cols-4">
+					<section className="lg:col-span-1">
+						<SettingsNavigation />
+					</section>
+
+					<section className="lg:col-span-3">
+						<Outlet />
+					</section>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/app/routes/settings+/_layout.tsx
+++ b/app/routes/settings+/_layout.tsx
@@ -12,9 +12,9 @@ import { Button } from '#app/components/ui/button.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { cn } from '#app/utils/misc.tsx'
 import { type Route } from './+types/_layout'
 import { type IconName } from '@/icon-name'
-import { cn } from '#app/utils/misc.tsx'
 
 const navigationItems = [
 	{
@@ -140,7 +140,11 @@ function SettingsNavigation() {
 									<Icon name={item.icon as IconName} />
 									<div className="flex-1">
 										<div className="font-medium">{item.title}</div>
-										<div className="text-muted-foreground text-xs">
+										<div
+											className={cn('text-muted-foreground text-xs', {
+												'text-destructive': item.type === 'destructive',
+											})}
+										>
 											{item.description}
 										</div>
 									</div>

--- a/app/routes/settings+/account.tsx
+++ b/app/routes/settings+/account.tsx
@@ -1,0 +1,186 @@
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
+import { data, Form } from 'react-router'
+import { z } from 'zod'
+import { ErrorList, Field } from '#app/components/forms.tsx'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '#app/components/ui/card.tsx'
+import { StatusButton } from '#app/components/ui/status-button.tsx'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { useIsPending } from '#app/utils/misc.tsx'
+import { NameSchema, UsernameSchema } from '#app/utils/user-validation.ts'
+import { type Route } from './+types/account.ts'
+import { twoFAVerificationType } from './profile.two-factor.tsx'
+
+const ProfileFormSchema = z.object({
+	name: NameSchema.nullable().default(null),
+	username: UsernameSchema,
+})
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const userId = await requireUserId(request)
+	const user = await prisma.user.findUniqueOrThrow({
+		where: { id: userId },
+		select: {
+			id: true,
+			name: true,
+			username: true,
+			email: true,
+			image: {
+				select: { objectKey: true },
+			},
+		},
+	})
+
+	const twoFactorVerification = await prisma.verification.findUnique({
+		select: { id: true },
+		where: { target_type: { type: twoFAVerificationType, target: userId } },
+	})
+
+	const password = await prisma.password.findUnique({
+		select: { userId: true },
+		where: { userId },
+	})
+
+	return {
+		user,
+		hasPassword: Boolean(password),
+		isTwoFactorEnabled: Boolean(twoFactorVerification),
+	}
+}
+
+const profileUpdateActionIntent = 'update-profile'
+
+export async function action({ request }: Route.ActionArgs) {
+	const userId = await requireUserId(request)
+	const formData = await request.formData()
+	const intent = formData.get('intent')
+	switch (intent) {
+		case profileUpdateActionIntent: {
+			return profileUpdateAction({ request, userId, formData })
+		}
+		default: {
+			throw new Response(`Invalid intent "${intent}"`, { status: 400 })
+		}
+	}
+}
+
+type ProfileActionArgs = {
+	request: Request
+	userId: string
+	formData: FormData
+}
+
+async function profileUpdateAction({ userId, formData }: ProfileActionArgs) {
+	const submission = await parseWithZod(formData, {
+		async: true,
+		schema: ProfileFormSchema.superRefine(async ({ username }, ctx) => {
+			const existingUsername = await prisma.user.findUnique({
+				where: { username },
+				select: { id: true },
+			})
+			if (existingUsername && existingUsername.id !== userId) {
+				ctx.addIssue({
+					path: ['username'],
+					code: z.ZodIssueCode.custom,
+					message: 'A user already exists with this username',
+				})
+			}
+		}),
+	})
+	if (submission.status !== 'success') {
+		return data(
+			{ result: submission.reply() },
+			{ status: submission.status === 'error' ? 400 : 200 },
+		)
+	}
+
+	const { username, name } = submission.value
+
+	await prisma.user.update({
+		select: { username: true },
+		where: { id: userId },
+		data: {
+			name: name,
+			username: username,
+		},
+	})
+
+	return {
+		result: submission.reply(),
+	}
+}
+
+export default function AccountSettings({
+	loaderData,
+	actionData,
+}: Route.ComponentProps) {
+	const isPending = useIsPending()
+
+	const [form, fields] = useForm({
+		id: 'edit-profile',
+		constraint: getZodConstraint(ProfileFormSchema),
+		lastResult: actionData?.result,
+		onValidate({ formData }) {
+			return parseWithZod(formData, { schema: ProfileFormSchema })
+		},
+		defaultValue: {
+			username: loaderData.user.username,
+			name: loaderData.user.name,
+		},
+	})
+	return (
+		<div className="space-y-6">
+			<Card>
+				<CardHeader>
+					<CardTitle>Profile Information</CardTitle>
+					<CardDescription>
+						Update your personal details and contact information. This
+						information will be used for your bookings and account verification.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-6">
+					<Form method="POST" {...getFormProps(form)}>
+						<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+							<div className="space-y-2">
+								<Field
+									labelProps={{
+										htmlFor: fields.username.id,
+										children: 'Username',
+									}}
+									inputProps={getInputProps(fields.username, { type: 'text' })}
+									errors={fields.username.errors}
+								/>
+							</div>
+							<Field
+								labelProps={{ htmlFor: fields.name.id, children: 'Name' }}
+								inputProps={getInputProps(fields.name, { type: 'text' })}
+								errors={fields.name.errors}
+							/>
+						</div>
+
+						<ErrorList errors={form.errors} id={form.errorId} />
+
+						<div className="flex justify-start">
+							<StatusButton
+								type="submit"
+								name="intent"
+								value={profileUpdateActionIntent}
+								status={isPending ? 'pending' : (form.status ?? 'idle')}
+								disabled={isPending}
+							>
+								Save changes
+							</StatusButton>
+						</div>
+					</Form>
+				</CardContent>
+			</Card>
+		</div>
+	)
+}

--- a/app/routes/settings+/privacy+/download.tsx
+++ b/app/routes/settings+/privacy+/download.tsx
@@ -1,0 +1,142 @@
+import { Link } from 'react-router'
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import { Checkbox } from '#app/components/ui/checkbox.tsx'
+import { Icon } from '#app/components/ui/icon.tsx'
+
+const dataTypes = [
+	{
+		id: 'profile',
+		label: 'Profile Information',
+		description: 'Your personal details, contact information, and preferences',
+		size: '2.3 KB',
+	},
+	{
+		id: 'bookings',
+		label: 'Booking History',
+		description: 'All your past and current bookings, including receipts',
+		size: '45.7 KB',
+		disabled: true,
+	},
+	{
+		id: 'payments',
+		label: 'Payment Information',
+
+		description:
+			'Payment methods and transaction history (sensitive data masked)',
+		size: '12.1 KB',
+		disabled: true,
+	},
+	{
+		id: 'preferences',
+		label: 'App Preferences',
+		description: 'Your settings, notifications, and customization choices',
+		size: '1.8 KB',
+		disabled: true,
+	},
+	{
+		id: 'activity',
+		label: 'Activity Logs',
+		description: 'Login history and account activity (last 90 days)',
+		size: '8.4 KB',
+		disabled: true,
+	},
+]
+
+export default function DownloadPage() {
+	return (
+		<div className="max-w-4xl">
+			<div className="mb-6">
+				<div className="mb-2 flex items-center gap-2">
+					<Icon name="download" className="h-6 w-6" />
+					<h1 className="text-2xl font-bold">Download Your Data</h1>
+				</div>
+				<p className="text-muted-foreground">
+					Export a copy of your data from our booking platform. This includes
+					all information associated with your account.
+				</p>
+			</div>
+
+			<div className="space-y-6">
+				<Alert>
+					<Icon name="info" className="h-4 w-4" />
+					<AlertTitle>
+						Your data will be compiled into a PDF document. This process may
+						take a few minutes for large datasets.
+					</AlertTitle>
+				</Alert>
+
+				<div className="space-y-4">
+					<h2 className="font-semibold">Select data to include:</h2>
+					<div className="space-y-3">
+						{dataTypes.map((dataType) => (
+							<div
+								key={dataType.id}
+								className="flex items-start space-x-3 rounded-lg border p-4"
+							>
+								<Checkbox
+									id={dataType.id}
+									defaultChecked
+									disabled={dataType.disabled}
+								/>
+								<div className="flex-1">
+									<div className="flex items-center justify-between">
+										<label
+											htmlFor={dataType.id}
+											className="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+										>
+											{dataType.label}
+										</label>
+										<span className="text-muted-foreground text-xs">
+											{dataType.size}
+										</span>
+									</div>
+									<p className="text-muted-foreground mt-1 text-xs">
+										{dataType.description}
+									</p>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+
+				<div className="bg-muted/50 rounded-lg p-4">
+					<div className="flex items-start gap-3">
+						<Icon name="file-text" className="mt-0.5 h-5 w-5" />
+						<div>
+							<h3 className="font-semibold">Export Format</h3>
+							<p className="text-muted-foreground text-sm">
+								Your data will be exported as a comprehensive PDF document with
+								all selected information organized by category.
+							</p>
+						</div>
+					</div>
+				</div>
+
+				<div className="bg-muted/50 rounded-lg p-4">
+					<div className="flex items-start gap-3">
+						<Icon name="calendar" className="mt-0.5 h-5 w-5" />
+						<div>
+							<h3 className="font-semibold">Data Retention</h3>
+							<p className="text-muted-foreground text-sm">
+								This export includes data from the last 2 years. Older data may
+								not be available due to our retention policies.
+							</p>
+						</div>
+					</div>
+				</div>
+
+				<Button asChild>
+					<Link
+						reloadDocument
+						download="my-daktarbari-data.pdf"
+						to="/resources/download-user-data"
+					>
+						<Icon name="download" className="mr-2 h-4 w-4" />
+						Generate & Download PDF
+					</Link>
+				</Button>
+			</div>
+		</div>
+	)
+}

--- a/app/routes/settings+/privacy+/download.tsx
+++ b/app/routes/settings+/privacy+/download.tsx
@@ -129,7 +129,7 @@ export default function DownloadPage() {
 				<Button asChild>
 					<Link
 						reloadDocument
-						download="my-daktarbari-data.pdf"
+						download="my-shuvodin-data.pdf"
 						to="/resources/download-user-data"
 					>
 						<Icon name="download" className="mr-2 h-4 w-4" />

--- a/app/routes/settings+/privacy+/index.tsx
+++ b/app/routes/settings+/privacy+/index.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'react-router'
+
+export async function loader() {
+	return redirect('/settings/privacy/download')
+}

--- a/app/routes/settings+/profile.change-email.server.tsx
+++ b/app/routes/settings+/profile.change-email.server.tsx
@@ -49,7 +49,7 @@ export async function handleVerification({
 
 	void sendEmail({
 		to: preUpdateUser.email,
-		subject: 'Epic Stack email changed',
+		subject: 'ShuvoDin email changed',
 		react: <EmailChangeNoticeEmail userId={user.id} />,
 	})
 

--- a/app/routes/settings+/profile.change-email.server.tsx
+++ b/app/routes/settings+/profile.change-email.server.tsx
@@ -79,7 +79,7 @@ export function EmailChangeEmail({
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>ShuvoDin Bari Email Change</E.Text>
+					<E.Text>ShuvoDin Email Change</E.Text>
 				</h1>
 				<p>
 					<E.Text>

--- a/app/routes/settings+/security+/2FA.disable.tsx
+++ b/app/routes/settings+/security+/2FA.disable.tsx
@@ -1,0 +1,220 @@
+import { Link, useFetcher } from 'react-router'
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx'
+import { Badge } from '#app/components/ui/badge.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import { Icon } from '#app/components/ui/icon.tsx'
+import { StatusButton } from '#app/components/ui/status-button.tsx'
+import { requireRecentVerification } from '#app/routes/_auth+/verify.server.ts'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { useDoubleCheck } from '#app/utils/misc.tsx'
+import { redirectWithToast } from '#app/utils/toast.server.ts'
+import { type Route } from './+types/2FA.disable'
+import { twoFAVerificationType } from './2FA.index'
+
+export async function loader({ request }: Route.LoaderArgs) {
+	await requireRecentVerification(request)
+	const userId = await requireUserId(request)
+	const verification = await prisma.verification.findUnique({
+		where: { target_type: { type: twoFAVerificationType, target: userId } },
+		select: { id: true },
+	})
+
+	const is2FAEnabled = Boolean(verification)
+	if (!is2FAEnabled) {
+		return redirectWithToast('/settings/security/2FA', {
+			title: '2FA Not Enabled',
+			type: 'error',
+			description:
+				'Two factor authentication is not currently enabled on your account.',
+		})
+	}
+	return {}
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	await requireRecentVerification(request)
+	const userId = await requireUserId(request)
+	await prisma.verification.delete({
+		where: { target_type: { target: userId, type: twoFAVerificationType } },
+	})
+	return redirectWithToast('/settings/profile/2FA', {
+		title: '2FA Disabled',
+		description: 'Two factor authentication has been disabled.',
+	})
+}
+
+export default function TwoFactorDisable() {
+	const disable2FAFetcher = useFetcher<typeof action>()
+	const dc = useDoubleCheck()
+	return (
+		<div className="max-w-2xl">
+			<div className="mb-6">
+				<div className="mb-2 flex items-center gap-2">
+					<Icon name="shield-off" className="text-destructive h-6 w-6" />
+					<h1 className="text-2xl font-bold">
+						Disable Two-Factor Authentication
+					</h1>
+					<Badge variant="destructive" className="ml-2">
+						Not Recommended
+					</Badge>
+				</div>
+				<p className="text-muted-foreground">
+					Remove the additional security layer from your account. This will make
+					your account more vulnerable to unauthorized access.
+				</p>
+			</div>
+
+			<div className="space-y-8">
+				{/* Current Status */}
+				<div className="space-y-4">
+					<h2 className="text-lg font-semibold">Current Security Status</h2>
+
+					<div className="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950/20">
+						<div className="flex items-center gap-3">
+							<Icon name="shield" className="h-5 w-5 text-green-600" />
+							<div>
+								<h3 className="font-semibold text-green-800 dark:text-green-200">
+									Two-Factor Authentication Enabled
+								</h3>
+								<p className="text-sm text-green-700 dark:text-green-300">
+									Your account is currently protected with 2FA using your
+									authenticator app.
+								</p>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				{/* Security Risks Warning */}
+				<div className="space-y-4">
+					<h2 className="text-destructive text-lg font-semibold">
+						Security Risks of Disabling 2FA
+					</h2>
+
+					<Alert className="border-destructive/50">
+						<Icon name="triangle-alert" className="h-4 w-4" />
+						<AlertTitle>
+							<strong>Warning:</strong> Disabling two-factor authentication
+							significantly reduces your account security.
+						</AlertTitle>
+					</Alert>
+
+					<div className="space-y-3">
+						<div className="border-destructive/20 bg-destructive/5 flex items-start gap-3 rounded-lg border p-4">
+							<Icon name="key" className="text-destructive mt-0.5 h-5 w-5" />
+							<div>
+								<h4 className="text-destructive font-semibold">
+									Password-Only Protection
+								</h4>
+								<p className="text-muted-foreground text-sm">
+									Your account will only be protected by your password, making
+									it vulnerable if your password is compromised.
+								</p>
+							</div>
+						</div>
+
+						<div className="border-destructive/20 bg-destructive/5 flex items-start gap-3 rounded-lg border p-4">
+							<Icon
+								name="triangle-alert"
+								className="text-destructive mt-0.5 h-5 w-5"
+							/>
+							<div>
+								<h4 className="text-destructive font-semibold">
+									Increased Risk of Unauthorized Access
+								</h4>
+								<p className="text-muted-foreground text-sm">
+									Attackers who obtain your password through phishing, data
+									breaches, or other means will have full access to your
+									account.
+								</p>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				{/* Alternative Solutions */}
+				<div className="space-y-4">
+					<h2 className="text-lg font-semibold">Consider These Alternatives</h2>
+
+					<div className="bg-muted/50 rounded-lg p-4">
+						<h3 className="mb-3 font-semibold">
+							Before disabling 2FA, consider:
+						</h3>
+						<ul className="text-muted-foreground space-y-2 text-sm">
+							<li className="flex items-start gap-2">
+								<span className="text-primary">•</span>
+								<span>
+									<strong>Add a backup authenticator:</strong> Set up 2FA on
+									multiple devices or apps
+								</span>
+							</li>
+							<li className="flex items-start gap-2">
+								<span className="text-primary">•</span>
+								<span>
+									<strong>Use passkeys:</strong> Consider setting up passkeys as
+									an alternative security method
+								</span>
+							</li>
+							<li className="flex items-start gap-2">
+								<span className="text-primary">•</span>
+								<span>
+									<strong>Contact support:</strong> If you're having issues with
+									2FA, our support team can help
+								</span>
+							</li>
+						</ul>
+					</div>
+
+					<div className="flex gap-2">
+						<Button asChild variant="outline">
+							<Link to="/settings/security/passkeys">
+								<Icon name="key" className="mr-2 h-4 w-4" />
+								Set Up Passkeys
+							</Link>
+						</Button>
+						<Button asChild variant="outline">
+							<Link to="/help">
+								<Icon name="shield" className="mr-2 h-4 w-4" />
+								Contact Support
+							</Link>
+						</Button>
+					</div>
+				</div>
+
+				{/* Disable Action */}
+				<div className="border-destructive/20 space-y-4 border-t pt-4">
+					<h2 className="text-destructive text-lg font-semibold">
+						Disable Two-Factor Authentication
+					</h2>
+
+					<p className="text-muted-foreground text-sm">
+						If you still want to proceed with disabling 2FA, you'll need to
+						verify your identity and acknowledge the security risks.
+					</p>
+					<disable2FAFetcher.Form method="POST">
+						<StatusButton
+							variant="destructive"
+							status={
+								disable2FAFetcher.state === 'loading' ? 'pending' : 'idle'
+							}
+							{...dc.getButtonProps({
+								className: 'mx-auto',
+								name: 'intent',
+								value: 'disable',
+								type: 'submit',
+							})}
+						>
+							<Icon name="shield-off" className="mr-2 h-4 w-4" />
+							{dc.doubleCheck ? (
+								<span>Are You sure?</span>
+							) : (
+								<span>I Understand the Risks - Disable 2FA</span>
+							)}
+						</StatusButton>
+					</disable2FAFetcher.Form>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/app/routes/settings+/security+/2FA.disable.tsx
+++ b/app/routes/settings+/security+/2FA.disable.tsx
@@ -38,7 +38,7 @@ export async function action({ request }: Route.ActionArgs) {
 	await prisma.verification.delete({
 		where: { target_type: { target: userId, type: twoFAVerificationType } },
 	})
-	return redirectWithToast('/settings/profile/2FA', {
+	return redirectWithToast('/settings/security/2FA', {
 		title: '2FA Disabled',
 		description: 'Two factor authentication has been disabled.',
 	})

--- a/app/routes/settings+/security+/2FA.index.tsx
+++ b/app/routes/settings+/security+/2FA.index.tsx
@@ -54,7 +54,7 @@ export default function TwoFactorPage({ loaderData }: Route.ComponentProps) {
 		<div className="space-y-6">
 			<Card>
 				<CardHeader>
-					<CardTitle className="flex items-center gap-2">
+					<CardTitle className="flex items-center gap-2 font-sans">
 						<Icon name="shield" className="h-5 w-5" />
 						Two-Factor Authentication
 						{loaderData.is2FAEnabled && (
@@ -73,9 +73,9 @@ export default function TwoFactorPage({ loaderData }: Route.ComponentProps) {
 				<CardContent className="space-y-6">
 					{!loaderData.is2FAEnabled ? (
 						<>
-							<Alert variant="destructive" className="w-max">
-								<Icon name="triangle-alert" className="h-4 w-4" />
-								<AlertTitle>
+							<Alert variant="destructive" className="flex w-max items-center">
+								<Icon name="triangle-alert" className="mt-1 h-4 w-4" />
+								<AlertTitle className="mb-0 font-sans text-base">
 									Two-factor authentication is currently{' '}
 									<strong>disabled</strong>. Your account is less secure without
 									2FA.
@@ -86,10 +86,12 @@ export default function TwoFactorPage({ loaderData }: Route.ComponentProps) {
 								<div className="flex items-start gap-3">
 									<Icon
 										name="shield-check"
-										className="mt-0.5 h-5 w-5 text-green-600"
+										className="h-5 w-5 text-green-600"
 									/>
 									<div>
-										<h3 className="font-semibold">Enhanced Security</h3>
+										<h3 className="font-sans font-semibold">
+											Enhanced Security
+										</h3>
 										<p className="text-muted-foreground text-sm">
 											Protect your account even if your password is compromised.
 										</p>
@@ -97,12 +99,11 @@ export default function TwoFactorPage({ loaderData }: Route.ComponentProps) {
 								</div>
 
 								<div className="flex items-start gap-3">
-									<Icon
-										name="smartphone"
-										className="mt-0.5 h-5 w-5 text-blue-600"
-									/>
+									<Icon name="smartphone" className="h-5 w-5 text-blue-600" />
 									<div>
-										<h3 className="font-semibold">Authenticator App</h3>
+										<h3 className="font-sans font-semibold">
+											Authenticator App
+										</h3>
 										<p className="text-muted-foreground text-sm">
 											Use{' '}
 											<a className="underline" href="https://1password.com/">

--- a/app/routes/settings+/security+/2FA.index.tsx
+++ b/app/routes/settings+/security+/2FA.index.tsx
@@ -120,7 +120,7 @@ export default function TwoFactorPage({ loaderData }: Route.ComponentProps) {
 									name="intent"
 									value="enable"
 									status={
-										enable2FAFetcher.state === 'loading' ? 'pending' : 'idle'
+										enable2FAFetcher.state !== 'idle' ? 'pending' : 'idle'
 									}
 								>
 									Enable Two-Factor Authentication

--- a/app/routes/settings+/security+/2FA.index.tsx
+++ b/app/routes/settings+/security+/2FA.index.tsx
@@ -1,0 +1,167 @@
+import { generateTOTP } from '@epic-web/totp'
+import { Link, redirect, useFetcher } from 'react-router'
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx'
+import { Badge } from '#app/components/ui/badge.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '#app/components/ui/card.tsx'
+import { Icon } from '#app/components/ui/icon.tsx'
+import { StatusButton } from '#app/components/ui/status-button.tsx'
+import { type VerificationTypes } from '#app/routes/_auth+/verify.tsx'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { twoFAVerifyVerificationType } from '../profile.two-factor.verify'
+import { type Route } from './+types/2FA.index'
+
+export const twoFAVerificationType = '2fa' satisfies VerificationTypes
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const userId = await requireUserId(request)
+	const verification = await prisma.verification.findUnique({
+		where: { target_type: { type: twoFAVerificationType, target: userId } },
+		select: { id: true },
+	})
+	return { is2FAEnabled: Boolean(verification) }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const userId = await requireUserId(request)
+	const { otp: _otp, ...config } = await generateTOTP()
+	const verificationData = {
+		...config,
+		type: twoFAVerifyVerificationType,
+		target: userId,
+	}
+	await prisma.verification.upsert({
+		where: {
+			target_type: { target: userId, type: twoFAVerifyVerificationType },
+		},
+		create: verificationData,
+		update: verificationData,
+	})
+	return redirect('/settings/security/2FA/verify')
+}
+
+export default function TwoFactorPage({ loaderData }: Route.ComponentProps) {
+	const enable2FAFetcher = useFetcher<typeof action>()
+
+	return (
+		<div className="space-y-6">
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						<Icon name="shield" className="h-5 w-5" />
+						Two-Factor Authentication
+						{loaderData.is2FAEnabled && (
+							<Badge variant="secondary" className="ml-2">
+								Enabled
+							</Badge>
+						)}
+					</CardTitle>
+
+					<CardDescription className="text-muted-foreground">
+						Add an extra layer of security to your account by requiring a
+						verification code in addition to your password.
+					</CardDescription>
+				</CardHeader>
+
+				<CardContent className="space-y-6">
+					{!loaderData.is2FAEnabled ? (
+						<>
+							<Alert variant="destructive" className="w-max">
+								<Icon name="triangle-alert" className="h-4 w-4" />
+								<AlertTitle>
+									Two-factor authentication is currently{' '}
+									<strong>disabled</strong>. Your account is less secure without
+									2FA.
+								</AlertTitle>
+							</Alert>
+
+							<div className="space-y-4">
+								<div className="flex items-start gap-3">
+									<Icon
+										name="shield-check"
+										className="mt-0.5 h-5 w-5 text-green-600"
+									/>
+									<div>
+										<h3 className="font-semibold">Enhanced Security</h3>
+										<p className="text-muted-foreground text-sm">
+											Protect your account even if your password is compromised.
+										</p>
+									</div>
+								</div>
+
+								<div className="flex items-start gap-3">
+									<Icon
+										name="smartphone"
+										className="mt-0.5 h-5 w-5 text-blue-600"
+									/>
+									<div>
+										<h3 className="font-semibold">Authenticator App</h3>
+										<p className="text-muted-foreground text-sm">
+											Use{' '}
+											<a className="underline" href="https://1password.com/">
+												1Password
+											</a>{' '}
+											app to generate codes.
+										</p>
+									</div>
+								</div>
+							</div>
+							<enable2FAFetcher.Form method="POST">
+								<StatusButton
+									type="submit"
+									name="intent"
+									value="enable"
+									status={
+										enable2FAFetcher.state === 'loading' ? 'pending' : 'idle'
+									}
+								>
+									Enable Two-Factor Authentication
+								</StatusButton>
+							</enable2FAFetcher.Form>
+						</>
+					) : (
+						<>
+							<Alert className="w-max">
+								<Icon name="shield-check" className="h-4 w-4" />
+								<AlertTitle>
+									Two-factor authentication is <strong>enabled</strong>. Your
+									account is protected with an additional security layer.
+								</AlertTitle>
+							</Alert>
+
+							<div className="space-y-4">
+								<div className="rounded-lg border p-4">
+									<div className="flex items-center justify-between">
+										<div className="flex items-center gap-3">
+											<Icon name="smartphone" className="h-5 w-5" />
+											<div>
+												<h3 className="font-semibold">Authenticator App</h3>
+												<p className="text-muted-foreground text-sm">
+													Configured on your mobile device
+												</p>
+											</div>
+										</div>
+										<Badge variant="outline">Active</Badge>
+									</div>
+								</div>
+
+								<div className="flex gap-2">
+									<Button asChild variant="destructive">
+										<Link to="disable">Disable Two-Factor Authentication</Link>
+									</Button>
+								</div>
+							</div>
+						</>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	)
+}

--- a/app/routes/settings+/security+/2FA.verify.tsx
+++ b/app/routes/settings+/security+/2FA.verify.tsx
@@ -100,16 +100,16 @@ export async function action({ request }: Route.ActionArgs) {
 			await prisma.verification.deleteMany({
 				where: { type: twoFAVerifyVerificationType, target: userId },
 			})
-			return redirect('/settings/profile/two-factor')
+			return redirect('/settings/security/2FA')
 		}
 		case 'verify': {
 			await prisma.verification.update({
 				where: {
 					target_type: { type: twoFAVerifyVerificationType, target: userId },
 				},
-				data: { type: twoFAVerificationType },
+				data: { type: twoFAVerificationType, target: userId },
 			})
-			return redirectWithToast('/settings/profile/two-factor', {
+			return redirectWithToast('/settings/security/2FA', {
 				type: 'success',
 				title: 'Enabled',
 				description: 'Two-factor authentication has been enabled.',

--- a/app/routes/settings+/security+/2FA.verify.tsx
+++ b/app/routes/settings+/security+/2FA.verify.tsx
@@ -1,0 +1,323 @@
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
+import { getTOTPAuthUri } from '@epic-web/totp'
+import * as QRCode from 'qrcode'
+import React from 'react'
+import { data, Form, redirect, useNavigation } from 'react-router'
+import { z } from 'zod'
+import { ErrorList, OTPField } from '#app/components/forms.tsx'
+import { Alert, AlertDescription } from '#app/components/ui/alert.tsx'
+import { Badge } from '#app/components/ui/badge.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import { Icon } from '#app/components/ui/icon.tsx'
+import { StatusButton } from '#app/components/ui/status-button.tsx'
+import { isCodeValid } from '#app/routes/_auth+/verify.server.ts'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { getDomainUrl, useIsPending } from '#app/utils/misc.tsx'
+import { redirectWithToast } from '#app/utils/toast.server.ts'
+import { type Route } from './+types/2FA.verify'
+import { twoFAVerificationType } from './2FA.index'
+
+const CancelSchema = z.object({ intent: z.literal('cancel') })
+const VerifySchema = z.object({
+	intent: z.literal('verify'),
+	code: z.string().min(6).max(6),
+})
+
+const ActionSchema = z.discriminatedUnion('intent', [
+	CancelSchema,
+	VerifySchema,
+])
+
+export const twoFAVerifyVerificationType = '2fa-verify'
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const userId = await requireUserId(request)
+	const verification = await prisma.verification.findUnique({
+		where: {
+			target_type: { type: twoFAVerifyVerificationType, target: userId },
+		},
+		select: {
+			id: true,
+			algorithm: true,
+			secret: true,
+			period: true,
+			digits: true,
+		},
+	})
+	if (!verification) {
+		return redirect('/settings/security/2FA')
+	}
+	const user = await prisma.user.findUniqueOrThrow({
+		where: { id: userId },
+		select: { email: true },
+	})
+	const issuer = new URL(getDomainUrl(request)).host
+	const otpUri = getTOTPAuthUri({
+		...verification,
+		accountName: user.email,
+		issuer,
+	})
+	const qrCode = await QRCode.toDataURL(otpUri)
+	return { otpUri, qrCode }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const userId = await requireUserId(request)
+	const formData = await request.formData()
+
+	const submission = await parseWithZod(formData, {
+		schema: () =>
+			ActionSchema.superRefine(async (data, ctx) => {
+				if (data.intent === 'cancel') return null
+				const codeIsValid = await isCodeValid({
+					code: data.code,
+					type: twoFAVerifyVerificationType,
+					target: userId,
+				})
+				if (!codeIsValid) {
+					ctx.addIssue({
+						path: ['code'],
+						code: z.ZodIssueCode.custom,
+						message: `Invalid code`,
+					})
+					return z.NEVER
+				}
+			}),
+		async: true,
+	})
+
+	if (submission.status !== 'success') {
+		return data(
+			{ result: submission.reply() },
+			{ status: submission.status === 'error' ? 400 : 200 },
+		)
+	}
+
+	switch (submission.value.intent) {
+		case 'cancel': {
+			await prisma.verification.deleteMany({
+				where: { type: twoFAVerifyVerificationType, target: userId },
+			})
+			return redirect('/settings/profile/two-factor')
+		}
+		case 'verify': {
+			await prisma.verification.update({
+				where: {
+					target_type: { type: twoFAVerifyVerificationType, target: userId },
+				},
+				data: { type: twoFAVerificationType },
+			})
+			return redirectWithToast('/settings/profile/two-factor', {
+				type: 'success',
+				title: 'Enabled',
+				description: 'Two-factor authentication has been enabled.',
+			})
+		}
+	}
+}
+
+export default function TwoFactorVerify({
+	loaderData,
+	actionData,
+}: Route.ComponentProps) {
+	const navigation = useNavigation()
+	const [copied, setCopied] = React.useState(false)
+
+	const isPending = useIsPending()
+	const pendingIntent = isPending ? navigation.formData?.get('intent') : null
+
+	const [form, fields] = useForm({
+		id: 'verify-form',
+		constraint: getZodConstraint(ActionSchema),
+		lastResult: actionData?.result,
+		onValidate({ formData }) {
+			return parseWithZod(formData, { schema: ActionSchema })
+		},
+	})
+	const lastSubmissionIntent = fields.intent.value
+
+	const handleCopy = async () => {
+		await navigator.clipboard.writeText(loaderData.otpUri)
+		setCopied(true)
+		setTimeout(() => setCopied(false), 2000)
+	}
+
+	const url = new URL(loaderData.otpUri)
+	const secret = url.searchParams.get('secret')
+	return (
+		<div className="max-w-2xl">
+			<div className="mb-6">
+				<div className="mb-2 flex items-center gap-2">
+					<Icon name="shield" className="h-6 w-6" />
+					<h1 className="text-2xl font-bold">
+						Enable Two-Factor Authentication
+					</h1>
+				</div>
+				<p className="text-muted-foreground">
+					Secure your account with an additional layer of protection
+				</p>
+			</div>
+
+			<div className="space-y-8">
+				<div className="space-y-4">
+					<div className="flex items-center gap-2">
+						<Badge
+							variant="outline"
+							className="flex h-6 w-6 items-center justify-center rounded-full p-0 text-xs"
+						>
+							1
+						</Badge>
+						<h2 className="text-lg font-semibold">Scan QR Code</h2>
+					</div>
+
+					<div className="bg-muted/30 rounded-lg p-6">
+						<div className="flex flex-col items-center space-y-4">
+							<div className="border-border flex h-64 w-64 items-center justify-center rounded-lg border-2 bg-white">
+								<img
+									alt="qr code"
+									src={loaderData.qrCode}
+									className="h-56 w-56"
+								/>
+							</div>
+							<p className="text-muted-foreground max-w-md text-center text-sm">
+								Scan this QR code with your authenticator app such as Google
+								Authenticator, Authy, or 1Password.
+							</p>
+						</div>
+					</div>
+				</div>
+
+				{/* Step 2: Manual Entry */}
+				<div className="space-y-4">
+					<div className="flex items-center gap-2">
+						<Badge
+							variant="outline"
+							className="flex h-6 w-6 items-center justify-center rounded-full p-0 text-xs"
+						>
+							2
+						</Badge>
+						<h2 className="text-lg font-semibold">
+							Can't scan? Enter manually
+						</h2>
+					</div>
+
+					<div className="bg-muted/30 rounded-lg p-4">
+						<p className="text-muted-foreground mb-3 text-sm">
+							If you cannot scan the QR code, you can manually add this account
+							to your authenticator app using this code:
+						</p>
+						<div className="bg-background flex items-center gap-2 rounded border p-3 font-mono text-sm">
+							<code className="flex-1 break-all">{secret}</code>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={handleCopy}
+								className="h-8 w-8 p-0"
+							>
+								{copied ? (
+									<Icon name="check" className="h-4 w-4" />
+								) : (
+									<Icon name="copy" className="h-4 w-4" />
+								)}
+							</Button>
+						</div>
+					</div>
+				</div>
+
+				{/* Step 3: Verification */}
+				<div className="space-y-4">
+					<div className="flex items-center gap-2">
+						<Badge
+							variant="outline"
+							className="flex h-6 w-6 items-center justify-center rounded-full p-0 text-xs"
+						>
+							3
+						</Badge>
+						<h2 className="text-lg font-semibold">Enter verification code</h2>
+					</div>
+
+					<div className="space-y-4">
+						<p className="text-muted-foreground text-sm">
+							Once you've added the account, enter the 6-digit code from your
+							authenticator app below.
+						</p>
+						<Form method="POST" {...getFormProps(form)} className="flex-1">
+							<div className="flex items-center justify-center">
+								<OTPField
+									labelProps={{
+										htmlFor: fields.code.id,
+										children: 'Code',
+									}}
+									inputProps={{
+										...getInputProps(fields.code, { type: 'text' }),
+										autoFocus: true,
+										autoComplete: 'one-time-code',
+									}}
+									errors={fields.code.errors}
+								/>
+							</div>
+							<div className="min-h-[32px] px-4 pt-1 pb-3">
+								<ErrorList id={form.errorId} errors={form.errors} />
+							</div>
+							<div className="flex justify-between gap-4">
+								<StatusButton
+									className="w-full"
+									status={
+										pendingIntent === 'verify'
+											? 'pending'
+											: lastSubmissionIntent === 'verify'
+												? (form.status ?? 'idle')
+												: 'idle'
+									}
+									type="submit"
+									name="intent"
+									value="verify"
+								>
+									Submit
+								</StatusButton>
+								<StatusButton
+									className="w-full"
+									variant="secondary"
+									status={
+										pendingIntent === 'cancel'
+											? 'pending'
+											: lastSubmissionIntent === 'cancel'
+												? (form.status ?? 'idle')
+												: 'idle'
+									}
+									type="submit"
+									name="intent"
+									value="cancel"
+									disabled={isPending}
+								>
+									Cancel
+								</StatusButton>
+							</div>
+						</Form>
+					</div>
+				</div>
+
+				{/* Important Notice */}
+				<Alert className="border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950">
+					<Icon name="shield" className="h-4 w-4" />
+					<AlertDescription>
+						<span>
+							<strong>Important:</strong>{' '}
+							<span>
+								Once you enable 2FA, you will need to enter a code from your
+								authenticator app every time you log in or perform important
+								actions.
+							</span>
+						</span>
+						<strong className="mt-1 block">
+							Do not lose access to your authenticator app, or you will lose
+							access to your account.
+						</strong>
+					</AlertDescription>
+				</Alert>
+			</div>
+		</div>
+	)
+}

--- a/app/routes/settings+/security+/change-email.server.tsx
+++ b/app/routes/settings+/security+/change-email.server.tsx
@@ -9,7 +9,7 @@ import { prisma } from '#app/utils/db.server.ts'
 import { sendEmail } from '#app/utils/email.server.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
 import { verifySessionStorage } from '#app/utils/verification.server.ts'
-import { newEmailAddressSessionKey } from './profile.change-email'
+import { newEmailAddressSessionKey } from './change-email'
 
 export async function handleVerification({
 	request,
@@ -79,7 +79,7 @@ export function EmailChangeEmail({
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>ShuvoDin Bari Email Change</E.Text>
+					<E.Text>Daktar Bari Email Change</E.Text>
 				</h1>
 				<p>
 					<E.Text>
@@ -100,11 +100,11 @@ function EmailChangeNoticeEmail({ userId }: { userId: string }) {
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>Your ShuvoDin email has been changed</E.Text>
+					<E.Text>Your Daktar Bari email has been changed</E.Text>
 				</h1>
 				<p>
 					<E.Text>
-						We're writing to let you know that your ShuvoDin email has been
+						We're writing to let you know that your Daktar Bari email has been
 						changed.
 					</E.Text>
 				</p>

--- a/app/routes/settings+/security+/change-email.server.tsx
+++ b/app/routes/settings+/security+/change-email.server.tsx
@@ -104,7 +104,7 @@ function EmailChangeNoticeEmail({ userId }: { userId: string }) {
 				</h1>
 				<p>
 					<E.Text>
-						We're writing to let you know that your ShivoDin email has been
+						We're writing to let you know that your ShuvoDin email has been
 						changed.
 					</E.Text>
 				</p>

--- a/app/routes/settings+/security+/change-email.server.tsx
+++ b/app/routes/settings+/security+/change-email.server.tsx
@@ -54,7 +54,7 @@ export async function handleVerification({
 	})
 
 	return redirectWithToast(
-		'/settings/profile',
+		'/settings/account',
 		{
 			title: 'Email Changed',
 			type: 'success',

--- a/app/routes/settings+/security+/change-email.server.tsx
+++ b/app/routes/settings+/security+/change-email.server.tsx
@@ -49,7 +49,7 @@ export async function handleVerification({
 
 	void sendEmail({
 		to: preUpdateUser.email,
-		subject: 'Epic Stack email changed',
+		subject: 'ShuvoDin email changed',
 		react: <EmailChangeNoticeEmail userId={user.id} />,
 	})
 

--- a/app/routes/settings+/security+/change-email.server.tsx
+++ b/app/routes/settings+/security+/change-email.server.tsx
@@ -79,7 +79,7 @@ export function EmailChangeEmail({
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>Daktar Bari Email Change</E.Text>
+					<E.Text>ShuvoDin Email Change</E.Text>
 				</h1>
 				<p>
 					<E.Text>
@@ -100,11 +100,11 @@ function EmailChangeNoticeEmail({ userId }: { userId: string }) {
 		<E.Html lang="en" dir="ltr">
 			<E.Container>
 				<h1>
-					<E.Text>Your Daktar Bari email has been changed</E.Text>
+					<E.Text>Your ShuvoDin email has been changed</E.Text>
 				</h1>
 				<p>
 					<E.Text>
-						We're writing to let you know that your Daktar Bari email has been
+						We're writing to let you know that your ShivoDin email has been
 						changed.
 					</E.Text>
 				</p>

--- a/app/routes/settings+/security+/change-email.tsx
+++ b/app/routes/settings+/security+/change-email.tsx
@@ -1,9 +1,16 @@
 import { getFormProps, getInputProps, useForm } from '@conform-to/react'
 import { getZodConstraint, parseWithZod } from '@conform-to/zod'
-import { type SEOHandle } from '@nasa-gcn/remix-seo'
-import { data, redirect, Form } from 'react-router'
+import { data, Form, redirect } from 'react-router'
 import { z } from 'zod'
 import { ErrorList, Field } from '#app/components/forms.tsx'
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx'
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '#app/components/ui/card.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
 import { StatusButton } from '#app/components/ui/status-button.tsx'
 import {
@@ -16,17 +23,10 @@ import { sendEmail } from '#app/utils/email.server.ts'
 import { useIsPending } from '#app/utils/misc.tsx'
 import { EmailSchema } from '#app/utils/user-validation.ts'
 import { verifySessionStorage } from '#app/utils/verification.server.ts'
-import { type Route } from './+types/profile.change-email.ts'
-import { EmailChangeEmail } from './profile.change-email.server.tsx'
-import { type BreadcrumbHandle } from './profile.tsx'
-
-export const handle: BreadcrumbHandle & SEOHandle = {
-	breadcrumb: <Icon name="envelope-closed">Change Email</Icon>,
-	getSitemapEntries: () => null,
-}
+import { type Route } from './+types/change-email'
+import { EmailChangeEmail } from './change-email.server'
 
 export const newEmailAddressSessionKey = 'new-email-address'
-
 const ChangeEmailSchema = z.object({
 	email: EmailSchema,
 })
@@ -79,7 +79,7 @@ export async function action({ request }: Route.ActionArgs) {
 
 	const response = await sendEmail({
 		to: submission.value.email,
-		subject: 'ShuvoDin Email Change Verification',
+		subject: `Daktar Bari Email Change Verification`,
 		react: <EmailChangeEmail verifyUrl={verifyUrl.toString()} otp={otp} />,
 	})
 
@@ -99,7 +99,7 @@ export async function action({ request }: Route.ActionArgs) {
 	}
 }
 
-export default function ChangeEmailIndex({
+export default function ChangeEmailPage({
 	loaderData,
 	actionData,
 }: Route.ComponentProps) {
@@ -114,33 +114,49 @@ export default function ChangeEmailIndex({
 
 	const isPending = useIsPending()
 	return (
-		<div>
-			<h1 className="text-h1">Change Email</h1>
-			<p>You will receive an email at the new email address to confirm.</p>
-			<p>
-				An email notice will also be sent to your old address{' '}
-				{loaderData.user.email}.
-			</p>
-			<div className="mx-auto mt-5 max-w-sm">
-				<Form method="POST" {...getFormProps(form)}>
-					<Field
-						labelProps={{ children: 'New Email' }}
-						inputProps={{
-							...getInputProps(fields.email, { type: 'email' }),
-							autoComplete: 'email',
-						}}
-						errors={fields.email.errors}
-					/>
-					<ErrorList id={form.errorId} errors={form.errors} />
-					<div>
+		<div className="space-y-6">
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						<Icon name="mail" className="h-5 w-5" />
+						Change Email Address
+					</CardTitle>
+					<CardDescription>
+						Update your email address. You'll need to verify your new email
+						before the change takes effect.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-6">
+					<Alert className="w-max">
+						<AlertTitle className="space-x-2">
+							<Icon name="shield" className="h-4 w-4" />
+							<span>
+								Your current email address is:{' '}
+								<strong>{loaderData.user.email}</strong>
+							</span>
+						</AlertTitle>
+					</Alert>
+
+					<Form method="POST" {...getFormProps(form)} className="space-y-4">
+						<Field
+							labelProps={{ children: 'New Email Address' }}
+							inputProps={{
+								...getInputProps(fields.email, { type: 'email' }),
+								placeholder: 'Enter your new email address',
+
+								autoComplete: 'email',
+							}}
+							errors={fields.email.errors}
+						/>
+						<ErrorList id={form.errorId} errors={form.errors} />
 						<StatusButton
 							status={isPending ? 'pending' : (form.status ?? 'idle')}
 						>
 							Send Confirmation
 						</StatusButton>
-					</div>
-				</Form>
-			</div>
+					</Form>
+				</CardContent>
+			</Card>
 		</div>
 	)
 }

--- a/app/routes/settings+/security+/change-email.tsx
+++ b/app/routes/settings+/security+/change-email.tsx
@@ -128,11 +128,13 @@ export default function ChangeEmailPage({
 				</CardHeader>
 				<CardContent className="space-y-6">
 					<Alert className="w-max">
-						<AlertTitle className="space-x-2">
+						<AlertTitle className="space-x-2 font-sans">
 							<Icon name="shield" className="h-4 w-4" />
 							<span>
 								Your current email address is:{' '}
-								<strong>{loaderData.user.email}</strong>
+								<strong className="text-primary">
+									{loaderData.user.email}
+								</strong>
 							</span>
 						</AlertTitle>
 					</Alert>

--- a/app/routes/settings+/security+/change-email.tsx
+++ b/app/routes/settings+/security+/change-email.tsx
@@ -79,7 +79,7 @@ export async function action({ request }: Route.ActionArgs) {
 
 	const response = await sendEmail({
 		to: submission.value.email,
-		subject: `Daktar Bari Email Change Verification`,
+		subject: `ShuvoDin Email Change Verification`,
 		react: <EmailChangeEmail verifyUrl={verifyUrl.toString()} otp={otp} />,
 	})
 

--- a/app/routes/settings+/security+/change-email.tsx
+++ b/app/routes/settings+/security+/change-email.tsx
@@ -145,7 +145,7 @@ export default function ChangeEmailPage({
 							inputProps={{
 								...getInputProps(fields.email, { type: 'email' }),
 								placeholder: 'Enter your new email address',
-
+								className: 'max-w-lg',
 								autoComplete: 'email',
 							}}
 							errors={fields.email.errors}

--- a/app/routes/settings+/security+/delete-account.tsx
+++ b/app/routes/settings+/security+/delete-account.tsx
@@ -1,3 +1,12 @@
+export async function loader() {
+	return {}
+}
+
+export async function action() {
+	// Implement account deletion logic here
+	return {}
+}
+
 export default function DeleteAccount() {
 	return (
 		<div>

--- a/app/routes/settings+/security+/delete-account.tsx
+++ b/app/routes/settings+/security+/delete-account.tsx
@@ -1,0 +1,9 @@
+export default function DeleteAccount() {
+	return (
+		<div>
+			<h1>Delete Account</h1>
+			<p>Are you sure you want to delete your account?</p>
+			<button>Delete Account</button>
+		</div>
+	)
+}

--- a/app/routes/settings+/security+/index.tsx
+++ b/app/routes/settings+/security+/index.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'react-router'
+
+export async function loader() {
+	return redirect('/settings/security/change-email')
+}

--- a/app/routes/settings+/security+/passkeys.tsx
+++ b/app/routes/settings+/security+/passkeys.tsx
@@ -94,7 +94,8 @@ export default function PasskeysPage({ loaderData }: Route.ComponentProps) {
 	const revalidator = useRevalidator()
 	const [error, setError] = useState<string | null>(null)
 
-	async function handlePasskeyRegistration() {
+	async function handlePasskeyRegistration(e: React.FormEvent) {
+		e.preventDefault()
 		try {
 			setError(null)
 			const resp = await fetch('/webauthn/registration')
@@ -138,7 +139,7 @@ export default function PasskeysPage({ loaderData }: Route.ComponentProps) {
 			<div className="space-y-6">
 				<Alert>
 					<Icon name="info" className="h-4 w-4" />
-					<AlertTitle>
+					<AlertTitle className="font-sans text-sm">
 						Passkeys use your device's built-in security features like Face ID,
 						Touch ID, or Windows Hello for authentication.
 					</AlertTitle>
@@ -147,8 +148,8 @@ export default function PasskeysPage({ loaderData }: Route.ComponentProps) {
 				<Spacer size="4xs" />
 
 				<div className="flex items-center justify-between">
-					<h2 className="text-lg font-semibold">Your Passkeys</h2>
-					<form action={handlePasskeyRegistration}>
+					<h2 className="font-sans text-lg font-semibold">Your Passkeys</h2>
+					<form onSubmit={handlePasskeyRegistration}>
 						<Button type="submit">
 							<Icon name="plus" className="mr-2 h-4 w-4" />
 							Register New Passkey

--- a/app/routes/settings+/security+/passkeys.tsx
+++ b/app/routes/settings+/security+/passkeys.tsx
@@ -1,0 +1,230 @@
+import { startRegistration } from '@simplewebauthn/browser'
+import { formatDistanceToNow } from 'date-fns'
+import { useState } from 'react'
+import { Form, useRevalidator } from 'react-router'
+import { z } from 'zod'
+import { Spacer } from '#app/components/spacer.tsx'
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx'
+import { Badge } from '#app/components/ui/badge.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import { Icon } from '#app/components/ui/icon.tsx'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { type Route } from './+types/passkeys'
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const userId = await requireUserId(request)
+	const passkeys = await prisma.passkey.findMany({
+		where: { userId },
+		orderBy: { createdAt: 'desc' },
+		select: {
+			id: true,
+			deviceType: true,
+			createdAt: true,
+		},
+	})
+	return { passkeys }
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const userId = await requireUserId(request)
+	const formData = await request.formData()
+	const intent = formData.get('intent')
+
+	if (intent === 'delete') {
+		const passkeyId = formData.get('passkeyId')
+		if (typeof passkeyId !== 'string') {
+			return Response.json(
+				{ status: 'error', error: 'Invalid passkey ID' },
+				{ status: 400 },
+			)
+		}
+
+		await prisma.passkey.delete({
+			where: {
+				id: passkeyId,
+				userId, // Ensure the passkey belongs to the user
+			},
+		})
+		return Response.json({ status: 'success' })
+	}
+
+	return Response.json(
+		{ status: 'error', error: 'Invalid intent' },
+		{ status: 400 },
+	)
+}
+
+const RegistrationOptionsSchema = z.object({
+	options: z.object({
+		rp: z.object({
+			id: z.string(),
+			name: z.string(),
+		}),
+		user: z.object({
+			id: z.string(),
+			name: z.string(),
+			displayName: z.string(),
+		}),
+		challenge: z.string(),
+		pubKeyCredParams: z.array(
+			z.object({
+				type: z.literal('public-key'),
+				alg: z.number(),
+			}),
+		),
+		authenticatorSelection: z
+			.object({
+				authenticatorAttachment: z
+					.enum(['platform', 'cross-platform'])
+					.optional(),
+				residentKey: z
+					.enum(['required', 'preferred', 'discouraged'])
+					.optional(),
+				userVerification: z
+					.enum(['required', 'preferred', 'discouraged'])
+					.optional(),
+				requireResidentKey: z.boolean().optional(),
+			})
+			.optional(),
+	}),
+}) satisfies z.ZodType<{ options: PublicKeyCredentialCreationOptionsJSON }>
+
+export default function PasskeysPage({ loaderData }: Route.ComponentProps) {
+	const revalidator = useRevalidator()
+	const [error, setError] = useState<string | null>(null)
+
+	async function handlePasskeyRegistration() {
+		try {
+			setError(null)
+			const resp = await fetch('/webauthn/registration')
+			const jsonResult = await resp.json()
+			const parsedResult = RegistrationOptionsSchema.parse(jsonResult)
+
+			const regResult = await startRegistration({
+				optionsJSON: parsedResult.options,
+			})
+
+			const verificationResp = await fetch('/webauthn/registration', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(regResult),
+			})
+
+			if (!verificationResp.ok) {
+				throw new Error('Failed to verify registration')
+			}
+
+			void revalidator.revalidate()
+		} catch (err) {
+			console.error('Failed to create passkey:', err)
+			setError('Failed to create passkey. Please try again.')
+		}
+	}
+
+	return (
+		<div className="max-w-4xl">
+			<div className="mb-6">
+				<div className="mb-2 flex items-center gap-2">
+					<Icon name="key" className="h-6 w-6" />
+					<h1 className="text-2xl font-bold">Manage Passkeys</h1>
+				</div>
+				<p className="text-muted-foreground">
+					Passkeys provide a secure, passwordless way to sign in using
+					biometrics or security keys.
+				</p>
+			</div>
+
+			<div className="space-y-6">
+				<Alert>
+					<Icon name="info" className="h-4 w-4" />
+					<AlertTitle>
+						Passkeys use your device's built-in security features like Face ID,
+						Touch ID, or Windows Hello for authentication.
+					</AlertTitle>
+				</Alert>
+
+				<Spacer size="4xs" />
+
+				<div className="flex items-center justify-between">
+					<h2 className="text-lg font-semibold">Your Passkeys</h2>
+					<form action={handlePasskeyRegistration}>
+						<Button type="submit">
+							<Icon name="plus" className="mr-2 h-4 w-4" />
+							Register New Passkey
+						</Button>
+					</form>
+				</div>
+				{error ? (
+					<div className="bg-destructive/15 text-destructive rounded-lg p-4">
+						{error}
+					</div>
+				) : null}
+
+				<ul className="space-y-3">
+					{loaderData.passkeys.map((passkey) => (
+						<li
+							key={passkey.id}
+							className="flex items-center justify-between rounded-lg border p-4"
+						>
+							<div className="flex items-center gap-3">
+								<Icon name="lock-closed" />
+
+								<div>
+									<h4 className="font-semibold">
+										{passkey.deviceType === 'platform'
+											? 'Device'
+											: 'Security Key'}
+									</h4>
+									<div className="text-muted-foreground flex items-center gap-2 text-sm">
+										<span>
+											Registered{' '}
+											{formatDistanceToNow(new Date(passkey.createdAt))} ago
+										</span>
+										<span>•</span>
+									</div>
+								</div>
+							</div>
+							<div className="flex items-center gap-2">
+								<Badge variant="outline">Active</Badge>
+								<Form method="POST">
+									<input type="hidden" name="passkeyId" value={passkey.id} />
+									<Button
+										type="submit"
+										name="intent"
+										value="delete"
+										variant="destructive"
+										size="sm"
+										className="flex items-center gap-2"
+									>
+										<Icon name="trash">Delete</Icon>
+									</Button>
+								</Form>
+							</div>
+						</li>
+					))}
+				</ul>
+
+				{loaderData.passkeys.length === 0 && (
+					<div className="bg-muted/50 rounded-lg border py-8 text-center">
+						<Icon
+							name="key"
+							className="text-muted-foreground mx-auto mb-4 h-12 w-12"
+						/>
+						<h3 className="mb-2 text-lg font-semibold">
+							No passkeys registered
+						</h3>
+						<p className="text-muted-foreground mb-4">
+							Register your first passkey to enable secure, passwordless
+							authentication.
+						</p>
+						<Button className="mt-4">
+							<Icon name="plus" className="mr-2 h-4 w-4" />
+							Register Your First Passkey
+						</Button>
+					</div>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/app/routes/settings+/security+/passkeys.tsx
+++ b/app/routes/settings+/security+/passkeys.tsx
@@ -99,6 +99,10 @@ export default function PasskeysPage({ loaderData }: Route.ComponentProps) {
 		try {
 			setError(null)
 			const resp = await fetch('/webauthn/registration')
+			if (!resp.ok) {
+				const errorText = await resp.text();
+				throw new Error(`Failed to fetch registration options: ${resp.status} ${resp.statusText} - ${errorText}`);
+			}
 			const jsonResult = await resp.json()
 			const parsedResult = RegistrationOptionsSchema.parse(jsonResult)
 

--- a/app/routes/settings+/security+/passkeys.tsx
+++ b/app/routes/settings+/security+/passkeys.tsx
@@ -198,7 +198,8 @@ export default function PasskeysPage({ loaderData }: Route.ComponentProps) {
 										size="sm"
 										className="flex items-center gap-2"
 									>
-										<Icon name="trash">Delete</Icon>
+										<Icon name="trash" />
+										Delete
 									</Button>
 								</Form>
 							</div>

--- a/app/routes/settings+/security+/passkeys.tsx
+++ b/app/routes/settings+/security+/passkeys.tsx
@@ -40,7 +40,7 @@ export async function action({ request }: Route.ActionArgs) {
 			)
 		}
 
-		await prisma.passkey.delete({
+		await prisma.passkey.deleteMany({
 			where: {
 				id: passkeyId,
 				userId, // Ensure the passkey belongs to the user

--- a/app/routes/settings+/security+/passkeys.tsx
+++ b/app/routes/settings+/security+/passkeys.tsx
@@ -99,10 +99,6 @@ export default function PasskeysPage({ loaderData }: Route.ComponentProps) {
 		try {
 			setError(null)
 			const resp = await fetch('/webauthn/registration')
-			if (!resp.ok) {
-				const errorText = await resp.text();
-				throw new Error(`Failed to fetch registration options: ${resp.status} ${resp.statusText} - ${errorText}`);
-			}
 			const jsonResult = await resp.json()
 			const parsedResult = RegistrationOptionsSchema.parse(jsonResult)
 
@@ -224,10 +220,12 @@ export default function PasskeysPage({ loaderData }: Route.ComponentProps) {
 							Register your first passkey to enable secure, passwordless
 							authentication.
 						</p>
-						<Button className="mt-4">
-							<Icon name="plus" className="mr-2 h-4 w-4" />
-							Register Your First Passkey
-						</Button>
+						<form onSubmit={handlePasskeyRegistration}>
+							<Button className="mt-4">
+								<Icon name="plus" className="mr-2 h-4 w-4" />
+								Register Your First Passkey
+							</Button>
+						</form>
 					</div>
 				)}
 			</div>

--- a/app/routes/settings+/security+/password.tsx
+++ b/app/routes/settings+/security+/password.tsx
@@ -1,0 +1,213 @@
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
+import { data, Form, redirect, Link } from 'react-router'
+import { z } from 'zod'
+import { ErrorList, Field } from '#app/components/forms.tsx'
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import { Icon } from '#app/components/ui/icon.tsx'
+import { StatusButton } from '#app/components/ui/status-button.tsx'
+import {
+	checkIsCommonPassword,
+	getPasswordHash,
+	requireUserId,
+	verifyUserPassword,
+} from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { useIsPending } from '#app/utils/misc.tsx'
+import { redirectWithToast } from '#app/utils/toast.server.ts'
+import { PasswordSchema } from '#app/utils/user-validation.ts'
+import { type Route } from './+types/password'
+
+const ChangePasswordForm = z
+	.object({
+		currentPassword: PasswordSchema,
+		newPassword: PasswordSchema,
+		confirmNewPassword: PasswordSchema,
+	})
+	.superRefine(({ confirmNewPassword, newPassword }, ctx) => {
+		if (confirmNewPassword !== newPassword) {
+			ctx.addIssue({
+				path: ['confirmNewPassword'],
+				code: z.ZodIssueCode.custom,
+				message: 'The passwords must match',
+			})
+		}
+	})
+
+async function requirePassword(userId: string) {
+	const password = await prisma.password.findUnique({
+		select: { userId: true },
+		where: { userId },
+	})
+	if (!password) {
+		throw redirect('/settings/security/password/create')
+	}
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const userId = await requireUserId(request)
+	await requirePassword(userId)
+	return {}
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const userId = await requireUserId(request)
+	await requirePassword(userId)
+	const formData = await request.formData()
+	const submission = await parseWithZod(formData, {
+		async: true,
+		schema: ChangePasswordForm.superRefine(
+			async ({ currentPassword, newPassword }, ctx) => {
+				if (currentPassword && newPassword) {
+					const user = await verifyUserPassword({ id: userId }, currentPassword)
+					if (!user) {
+						ctx.addIssue({
+							path: ['currentPassword'],
+							code: z.ZodIssueCode.custom,
+							message: 'Incorrect password.',
+						})
+					}
+					const isCommonPassword = await checkIsCommonPassword(newPassword)
+					if (isCommonPassword) {
+						ctx.addIssue({
+							path: ['newPassword'],
+							code: 'custom',
+							message: 'Password is too common',
+						})
+					}
+				}
+			},
+		),
+	})
+	if (submission.status !== 'success') {
+		return data(
+			{
+				result: submission.reply({
+					hideFields: ['currentPassword', 'newPassword', 'confirmNewPassword'],
+				}),
+			},
+			{ status: submission.status === 'error' ? 400 : 200 },
+		)
+	}
+
+	const { newPassword } = submission.value
+
+	await prisma.user.update({
+		select: { username: true },
+		where: { id: userId },
+		data: {
+			password: {
+				update: {
+					hash: await getPasswordHash(newPassword),
+				},
+			},
+		},
+	})
+
+	return redirectWithToast(
+		'/settings/account',
+		{
+			type: 'success',
+			title: 'Password Changed',
+			description: 'Your password has been changed.',
+		},
+		{ status: 302 },
+	)
+}
+
+export default function ChangePasswordPage({
+	actionData,
+}: Route.ComponentProps) {
+	const isPending = useIsPending()
+
+	const [form, fields] = useForm({
+		id: 'password-change-form',
+		constraint: getZodConstraint(ChangePasswordForm),
+		lastResult: actionData?.result,
+		onValidate({ formData }) {
+			return parseWithZod(formData, { schema: ChangePasswordForm })
+		},
+		shouldRevalidate: 'onBlur',
+	})
+
+	return (
+		<div className="max-w-2xl">
+			<div className="mb-6">
+				<div className="mb-2 flex items-center gap-2">
+					<Icon name="key" className="h-6 w-6" />
+					<h1 className="text-2xl font-bold">Change Password</h1>
+				</div>
+				<p className="text-muted-foreground">
+					Update your password to keep your account secure. Choose a strong
+					password that you haven't used elsewhere.
+				</p>
+			</div>
+			<Form method="POST" {...getFormProps(form)} className="space-y-4">
+				<Alert>
+					<Icon name="info" className="h-4 w-4" />
+					<AlertTitle>
+						Your password must be at least 8 characters long and include a mix
+						of letters, numbers, and symbols.
+					</AlertTitle>
+				</Alert>
+
+				<div>
+					<Field
+						labelProps={{ children: 'Current Password' }}
+						inputProps={{
+							...getInputProps(fields.currentPassword, { type: 'password' }),
+							autoComplete: 'current-password',
+							placeholder: 'Enter your current password',
+						}}
+						errors={fields.currentPassword.errors}
+					/>
+					<Field
+						labelProps={{ children: 'New Password' }}
+						inputProps={{
+							...getInputProps(fields.newPassword, { type: 'password' }),
+							autoComplete: 'new-password',
+							placeholder: 'Enter your new password',
+						}}
+						errors={fields.newPassword.errors}
+					/>
+					<Field
+						labelProps={{ children: 'Confirm New Password' }}
+						inputProps={{
+							...getInputProps(fields.confirmNewPassword, {
+								type: 'password',
+							}),
+							placeholder: 'Confirm your new password',
+							autoComplete: 'new-password',
+						}}
+						errors={fields.confirmNewPassword.errors}
+					/>
+				</div>
+				<ErrorList id={form.errorId} errors={form.errors} />
+
+				<div className="bg-muted/50 rounded-lg p-4">
+					<h3 className="mb-2 font-semibold">Password Requirements:</h3>
+					<ul className="text-muted-foreground space-y-1 text-sm">
+						<li>• At least 8 characters long</li>
+						<li>• Contains uppercase and lowercase letters</li>
+						<li>• Includes at least one number</li>
+						<li>• Has at least one special character (!@#$%^&*)</li>
+					</ul>
+				</div>
+
+				<div className="grid w-full grid-cols-2 gap-6">
+					<Button variant="secondary" asChild>
+						<Link to="..">Cancel</Link>
+					</Button>
+					<StatusButton
+						type="submit"
+						className="font-semibold"
+						status={isPending ? 'pending' : (form.status ?? 'idle')}
+					>
+						Change Password
+					</StatusButton>
+				</div>
+			</Form>
+		</div>
+	)
+}

--- a/app/routes/settings+/security+/password_.create.tsx
+++ b/app/routes/settings+/security+/password_.create.tsx
@@ -1,0 +1,164 @@
+import { getFormProps, getInputProps, useForm } from '@conform-to/react'
+import { getZodConstraint, parseWithZod } from '@conform-to/zod'
+import { data, Form, Link, redirect } from 'react-router'
+import { ErrorList, Field } from '#app/components/forms.tsx'
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx'
+import { Button } from '#app/components/ui/button.tsx'
+import { Icon } from '#app/components/ui/icon.tsx'
+import { StatusButton } from '#app/components/ui/status-button.tsx'
+import {
+	checkIsCommonPassword,
+	getPasswordHash,
+	requireUserId,
+} from '#app/utils/auth.server.ts'
+import { prisma } from '#app/utils/db.server.ts'
+import { useIsPending } from '#app/utils/misc.tsx'
+import { PasswordAndConfirmPasswordSchema } from '#app/utils/user-validation.ts'
+import { type Route } from './+types/password_.create'
+
+const CreatePasswordForm = PasswordAndConfirmPasswordSchema
+
+async function requireNoPassword(userId: string) {
+	const password = await prisma.password.findUnique({
+		select: { userId: true },
+		where: { userId },
+	})
+	if (password) {
+		throw redirect('/settings/security/password')
+	}
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+	const userId = await requireUserId(request)
+	await requireNoPassword(userId)
+	return {}
+}
+
+export async function action({ request }: Route.ActionArgs) {
+	const userId = await requireUserId(request)
+	await requireNoPassword(userId)
+	const formData = await request.formData()
+	const submission = await parseWithZod(formData, {
+		async: true,
+		schema: CreatePasswordForm.superRefine(async ({ password }, ctx) => {
+			const isCommonPassword = await checkIsCommonPassword(password)
+			if (isCommonPassword) {
+				ctx.addIssue({
+					path: ['password'],
+					code: 'custom',
+					message: 'Password is too common',
+				})
+			}
+		}),
+	})
+	if (submission.status !== 'success') {
+		return data(
+			{
+				result: submission.reply({
+					hideFields: ['password', 'confirmPassword'],
+				}),
+			},
+			{ status: submission.status === 'error' ? 400 : 200 },
+		)
+	}
+
+	const { password } = submission.value
+
+	await prisma.user.update({
+		select: { username: true },
+		where: { id: userId },
+		data: {
+			password: {
+				create: {
+					hash: await getPasswordHash(password),
+				},
+			},
+		},
+	})
+
+	return redirect(`/settings/profile`, { status: 302 })
+}
+
+export default function PasswordCreate({ actionData }: Route.ComponentProps) {
+	const isPending = useIsPending()
+
+	const [form, fields] = useForm({
+		id: 'password-create-form',
+		constraint: getZodConstraint(CreatePasswordForm),
+		lastResult: actionData?.result,
+		onValidate({ formData }) {
+			return parseWithZod(formData, { schema: CreatePasswordForm })
+		},
+		shouldRevalidate: 'onBlur',
+	})
+	return (
+		<div className="max-w-2xl">
+			<div className="mb-6">
+				<div className="mb-2 flex items-center gap-2">
+					<Icon name="key" className="h-6 w-6" />
+					<h1 className="text-2xl font-bold">Change Password</h1>
+				</div>
+				<p className="text-muted-foreground">
+					Update your password to keep your account secure. Choose a strong
+					password that you haven't used elsewhere.
+				</p>
+			</div>
+			<Form method="POST" {...getFormProps(form)} className="space-y-4">
+				<Alert>
+					<Icon name="info" className="h-4 w-4" />
+					<AlertTitle>
+						Your password must be at least 8 characters long and include a mix
+						of letters, numbers, and symbols.
+					</AlertTitle>
+				</Alert>
+
+				<div>
+					<Field
+						labelProps={{ children: 'New Password' }}
+						inputProps={{
+							...getInputProps(fields.password, { type: 'password' }),
+							autoComplete: 'new-password',
+							placeholder: 'Enter your new password',
+						}}
+						errors={fields.password.errors}
+					/>
+					<Field
+						labelProps={{ children: 'Confirm New Password' }}
+						inputProps={{
+							...getInputProps(fields.confirmPassword, {
+								type: 'password',
+							}),
+							placeholder: 'Confirm your new password',
+							autoComplete: 'new-password',
+						}}
+						errors={fields.confirmPassword.errors}
+					/>
+				</div>
+				<ErrorList id={form.errorId} errors={form.errors} />
+
+				<div className="bg-muted/50 rounded-lg p-4">
+					<h3 className="mb-2 font-semibold">Password Requirements:</h3>
+					<ul className="text-muted-foreground space-y-1 text-sm">
+						<li>• At least 8 characters long</li>
+						<li>• Contains uppercase and lowercase letters</li>
+						<li>• Includes at least one number</li>
+						<li>• Has at least one special character (!@#$%^&*)</li>
+					</ul>
+				</div>
+
+				<div className="grid w-full grid-cols-2 gap-6">
+					<Button variant="secondary" asChild>
+						<Link to="..">Cancel</Link>
+					</Button>
+					<StatusButton
+						type="submit"
+						className="font-semibold"
+						status={isPending ? 'pending' : (form.status ?? 'idle')}
+					>
+						Create Password
+					</StatusButton>
+				</div>
+			</Form>
+		</div>
+	)
+}

--- a/app/routes/settings+/security+/password_.create.tsx
+++ b/app/routes/settings+/security+/password_.create.tsx
@@ -76,7 +76,7 @@ export async function action({ request }: Route.ActionArgs) {
 		},
 	})
 
-	return redirect(`/settings/profile`, { status: 302 })
+	return redirect(`/settings/account`, { status: 302 })
 }
 
 export default function PasswordCreate({ actionData }: Route.ComponentProps) {

--- a/app/routes/settings+/security+/password_.create.tsx
+++ b/app/routes/settings+/security+/password_.create.tsx
@@ -96,7 +96,7 @@ export default function PasswordCreate({ actionData }: Route.ComponentProps) {
 			<div className="mb-6">
 				<div className="mb-2 flex items-center gap-2">
 					<Icon name="key" className="h-6 w-6" />
-					<h1 className="text-2xl font-bold">Change Password</h1>
+					<h1 className="text-2xl font-bold">Create Password</h1>
 				</div>
 				<p className="text-muted-foreground">
 					Update your password to keep your account secure. Choose a strong

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "epic-stack-template"
+app = "shuvodin-template"
 primary_region = "sjc"
 kill_signal = "SIGINT"
 kill_timeout = 5

--- a/other/svg-icons/copy.svg
+++ b/other/svg-icons/copy.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/copy.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></g></svg>

--- a/other/svg-icons/ellipsis.svg
+++ b/other/svg-icons/ellipsis.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/ellipsis.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></g></svg>

--- a/other/svg-icons/info.svg
+++ b/other/svg-icons/info.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/info.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4m0-4h.01"/></g></svg>

--- a/other/svg-icons/key.svg
+++ b/other/svg-icons/key.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/key.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="m15.5 7.5l2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4m2-2l-9.6 9.6"/><circle cx="7.5" cy="15.5" r="5.5"/></g></svg>

--- a/other/svg-icons/lock.svg
+++ b/other/svg-icons/lock.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/lock.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></g></svg>

--- a/other/svg-icons/monitor-smartphone.svg
+++ b/other/svg-icons/monitor-smartphone.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/monitor-smartphone.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M18 8V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h8m-2 4v-3.96v3.15M7 19h5"/><rect width="6" height="10" x="16" y="12" rx="2"/></g></svg>

--- a/other/svg-icons/monitor.svg
+++ b/other/svg-icons/monitor.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/monitor.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="20" height="14" x="2" y="3" rx="2"/><path d="M8 21h8m-4-4v4"/></g></svg>

--- a/other/svg-icons/shield-check.svg
+++ b/other/svg-icons/shield-check.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/shield-check.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12l2 2l4-4"/></g></svg>

--- a/other/svg-icons/shield-off.svg
+++ b/other/svg-icons/shield-off.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/shield-off.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m2 2l20 20M5 5a1 1 0 0 0-1 1v7c0 5 3.5 7.5 7.67 8.94a1 1 0 0 0 .67.01c2.35-.82 4.48-1.97 5.9-3.71M9.309 3.652A12.3 12.3 0 0 0 11.24 2.28a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1v7a10 10 0 0 1-.08 1.264"/></svg>

--- a/other/svg-icons/smartphone.svg
+++ b/other/svg-icons/smartphone.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/smartphone.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><rect width="14" height="20" x="5" y="2" rx="2" ry="2"/><path d="M12 18h.01"/></g></svg>

--- a/other/svg-icons/trash-2.svg
+++ b/other/svg-icons/trash-2.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/trash-2.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 11v6m4-6v6m5-11v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>

--- a/other/svg-icons/triangle-alert.svg
+++ b/other/svg-icons/triangle-alert.svg
@@ -1,0 +1,2 @@
+<!-- Downloaded from lucide/triangle-alert.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m21.73 18l-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3M12 9v4m0 4h.01"/></svg>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,5 +1,5 @@
 {
-	"name": "Shuvo Din",
+	"name": "ShuvoDin",
 	"short_name": "ShuvoDin",
 	"start_url": "/",
 	"icons": [

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
 	"name": "Shuvo Din",
-	"short_name": "Shuvo Din",
+	"short_name": "ShuvoDin",
 	"start_url": "/",
 	"icons": [
 		{

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-	"name": "Epic Notes",
-	"short_name": "Epic Notes",
+	"name": "Shuvo Din",
+	"short_name": "Shuvo Din",
 	"start_url": "/",
 	"icons": [
 		{

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -1,7 +1,7 @@
 module.exports = async (...args) => {
 	const { default: main } = await import('./index.mjs')
 	await main(...args).catch((err) => {
-		console.error('Oh no! Something went wrong initializing your shuvodin app:')
+		console.error('Oh no! Something went wrong initializing your Shuvodin app:')
 		console.error(err)
 		process.exit(1)
 	})

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -1,7 +1,7 @@
 module.exports = async (...args) => {
 	const { default: main } = await import('./index.mjs')
 	await main(...args).catch((err) => {
-		console.error('Oh no! Something went wrong initializing your epic app:')
+		console.error('Oh no! Something went wrong initializing your shuvodin app:')
 		console.error(err)
 		process.exit(1)
 	})

--- a/tests/e2e/search.test.ts
+++ b/tests/e2e/search.test.ts
@@ -11,7 +11,7 @@ test('Search from home page', async ({ page, insertNewUser }) => {
 	await page.waitForURL(
 		`/users?${new URLSearchParams({ search: newUser.username })}`,
 	)
-	await expect(page.getByText('Epic Notes Users')).toBeVisible()
+	await expect(page.getByText('ShuvoDin Users')).toBeVisible()
 	const userList = page.getByRole('main').getByRole('list')
 	await expect(userList.getByRole('listitem')).toHaveCount(1)
 	invariant(newUser.name, 'User name not found')


### PR DESCRIPTION
This pull request introduces several new UI components and refactors the settings layout, along with updates to branding and navigation throughout the app. The most significant changes are the addition of reusable UI components (`Alert` and `Breadcrumb`), a comprehensive new settings layout, and updates to app branding from "Epic Notes" to "ShuvoDin". Below are the key changes grouped by theme:

**New UI Components:**

* Added a reusable `Alert` component with support for variants, titles, and descriptions in `app/components/ui/alert.tsx`.
* Added a complete `Breadcrumb` component suite for navigation, including list, item, link, page, separator, and ellipsis in `app/components/ui/breadcrumb.tsx`.

**Settings Layout and Navigation:**

* Introduced a new settings layout in `app/routes/settings+/_layout.tsx` featuring a sidebar navigation, breadcrumb navigation, and download data button. The navigation is organized by account, security, privacy, sessions, and danger zone sections.
* Updated the settings/profile link to settings/account for consistency in `app/routes/profiles+/$username.tsx`.

**Branding Updates:**

* Changed all references of "Epic Notes" to "ShuvoDin" in page titles, email subjects, and descriptions across authentication and notes-related routes. This includes signup, login, password recovery, onboarding, and notes pages. [[1]](diffhunk://#diff-a4d0343de268777f78f1ce54aa51e8ff5014892081a4c404225bfa80b001698bL117-R117) [[2]](diffhunk://#diff-5df3f6a6ee4250f798f78c011fa4af88548c173478753b0ad5b65b3588875705L302-R302) [[3]](diffhunk://#diff-897fbd8af91929ddfbafa34a818d39631843fcd19c17abe7be1e8a7a25af0c70L131-R131) [[4]](diffhunk://#diff-923ad137aa8bc1194bbf35ff5fa44684fc30cbfc6fbfd97cf39f697c0d9bd2c9L163-R163) [[5]](diffhunk://#diff-331c88f78b5e858ed3d1495c1a16bb86ba7f3710bba3a1e165cb0e89faf441faL79-R79) [[6]](diffhunk://#diff-0317bf6ecc976d2047fb71fa3f9f73bb1bffc8d09eb4bd14338be8178a009d35L75-R75) [[7]](diffhunk://#diff-0317bf6ecc976d2047fb71fa3f9f73bb1bffc8d09eb4bd14338be8178a009d35L104-R104) [[8]](diffhunk://#diff-0317bf6ecc976d2047fb71fa3f9f73bb1bffc8d09eb4bd14338be8178a009d35L121-R121) [[9]](diffhunk://#diff-5664463d343b8c34670761c69ef41874d982a66c174568acc471732408aac2fbL221-R221) [[10]](diffhunk://#diff-6831750527255f928661bbd1754bd0ec2c668c42db90a96ce91464640abc1a2cL21-R24)

**User Experience Improvements:**

* Updated the main navigation in `app/root.tsx` to conditionally show a "Vendor Profile" button if the user is a vendor, and refactored the "Sign In" button to use a link for better accessibility and navigation.
* Improved profile page title formatting to use the user's display name if available in `app/routes/profiles+/$username.tsx`.

**Cleanup:**

* Removed the "Notes" link from the user dropdown menu for a cleaner user interface in `app/components/user-dropdown.tsx`.This pull request introduces a comprehensive overhaul of the user settings section, adding new UI components and pages, improving navigation, and updating branding across the app. The main focus is on enhancing the settings experience with structured navigation, breadcrumbs, and user-friendly forms for profile and privacy management.

**New UI Components**

* Added reusable `Alert` component with variants for displaying notifications and warnings in the UI (`app/components/ui/alert.tsx`).
* Added a full-featured `Breadcrumb` component suite (`Breadcrumb`, `BreadcrumbList`, `BreadcrumbItem`, etc.) for improved navigation and accessibility in settings pages (`app/components/ui/breadcrumb.tsx`).

**Settings Section Overhaul**

* Implemented a new settings layout page with sidebar navigation, breadcrumbs, and a download data button. The navigation is grouped by theme (Account, Security, Privacy & Data, Sessions, Danger Zone) and is dynamically highlighted based on the current route (`app/routes/settings+/_layout.tsx`).
* Added a new account settings page with a validated profile form for updating username and name, including backend logic for form submission and validation (`app/routes/settings+/account.tsx`).
* Introduced a privacy download page allowing users to select data categories to export and download as a PDF, with clear UI and informative alerts (`app/routes/settings+/privacy+/download.tsx`).
* Added redirect from `/settings/privacy` to `/settings/privacy/download` for improved navigation (`app/routes/settings+/privacy+/index.tsx`).

**Branding and Miscellaneous Updates**

* Updated email subject lines and content from "Epic Notes" to "ShuvoDin" for consistency with new branding (`app/routes/settings+/profile.change-email.server.tsx`, `app/routes/settings+/profile.change-email.tsx`). [[1]](diffhunk://#diff-b856ad3b2793cacce3c0cb54af5462f691612f00729ad57b7921e360378c43d0L82-R82) [[2]](diffhunk://#diff-b856ad3b2793cacce3c0cb54af5462f691612f00729ad57b7921e360378c43d0L103-R107) [[3]](diffhunk://#diff-693d8e2662967ac9dc8cce164f13f805d0913096f2b4f6974c846ab2cd332ef8L82-R82)
* Improved profile page metadata to use the user's name if available, otherwise falling back to username (`app/routes/profiles+/$username.tsx`).<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
